### PR TITLE
Raw Message Support

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,4 @@
+module.exports = [
+  { type: 'team_join',      name: 'user:new',     trigger: '{USER:NEW}' },
+  { type: 'reaction_added', name: 'reaction:new', trigger: '{REACTION:NEW}' },
+];

--- a/lib/snarl.js
+++ b/lib/snarl.js
@@ -46,6 +46,24 @@ Snarl.prototype.autoload = function() {
   return self;
 }
 
+Snarl.prototype._interpretRaw = function(message) {
+  var self = this;
+  var options = self.triggers ? Object.keys(self.triggers) : [];
+
+  if (self.debug) {
+    console.log('raw message:', message);
+  }
+
+  if (message.type === 'reaction_added') {
+    self.emit('reaction:new'. message.user);
+  }
+
+  if (message.type === 'team_join') {
+    self.emit('user:new'. message.user);
+  }
+
+}
+
 Snarl.prototype._interpret = function(message) {
   var self = this;
   var options = self.triggers ? Object.keys(self.triggers) : [];
@@ -192,6 +210,14 @@ Snarl.prototype.start = function() {
         }]);
       });
     }
+
+    if (plugin['{USER:NEW}']) {
+      slack.on('user:new', function(user) {
+        slack.triggers['{USER:NEW}'].apply(slack, [user, function(err, reply) {
+          //slack.emit('response', reply, message);
+        }]);
+      });
+    }
   });
 
   slack.on('open', function() {
@@ -201,6 +227,7 @@ Snarl.prototype.start = function() {
   slack.on('open', slack._channelInventory);
   slack.on('open', slack._userInventory);
 
+  slack.on('raw_message', self._interpretRaw);
   slack.on('message', self._interpret);
 
   slack.on('response', function(response, message) {

--- a/lib/snarl.js
+++ b/lib/snarl.js
@@ -3,14 +3,16 @@ var util = require('util');
 var join = require('oxford-join');
 var level = require('level');
 var Slack = require('./slack');
+var eventList = require('./events');
 //var Eliza = require('./eliza');
 
 function Snarl(config) {
   this.config = config;
   this.debug = config.debug;
   this.name = config.name;
-  this.slack = new Slack(config.slack.token, true, true);
   this.db = level(config.store);
+  this.slack = new Slack(config.slack.token, true, true);
+  this.events = eventList;
   this._plugins = [];
 }
 
@@ -54,13 +56,11 @@ Snarl.prototype._interpretRaw = function(message) {
     console.log('raw message:', message);
   }
 
-  if (message.type === 'reaction_added') {
-    self.emit('reaction:new'. message.user);
-  }
-
-  if (message.type === 'team_join') {
-    self.emit('user:new'. message.user);
-  }
+  self.events.forEach(function(e) {
+    if (message.type === e.type) {
+      self.emit(e.name, message);
+    }
+  });
 
 }
 
@@ -194,6 +194,7 @@ Snarl.prototype.start = function() {
   slack.conversations = [];
   slack.conversationTimers = {};
   slack.db = self.db;
+  slack.events = self.events;
 
   // configure default triggers
   slack.triggers = require('./triggers');
@@ -203,21 +204,15 @@ Snarl.prototype.start = function() {
     slack.plugins.push(plugin);
     slack.triggers = _.extend(slack.triggers, plugin);
 
-    if (plugin['{USER}']) {
-      slack.on('user', function(user) {
-        slack.triggers['{USER}'].apply(slack, [user, function(err, reply) {
-          //slack.emit('response', reply, message);
-        }]);
-      });
-    }
-
-    if (plugin['{USER:NEW}']) {
-      slack.on('user:new', function(user) {
-        slack.triggers['{USER:NEW}'].apply(slack, [user, function(err, reply) {
-          //slack.emit('response', reply, message);
-        }]);
-      });
-    }
+    slack.events.forEach(function(e) {
+      if (plugin[e.trigger]) {
+        slack.on(e.name, function(obj) {
+          slack.triggers[e.trigger].apply(slack, [obj, function(err, reply) {
+            //slack.emit('response', reply, message);
+          }]);
+        });
+      }
+    });
   });
 
   slack.on('open', function() {


### PR DESCRIPTION
This adds support for raw messages, so the underlying API is more exposed.  Specifically, this adds support for plugins to use:

`team_join`
`reaction_added`

Further updates would bind similar events to _all_ native message types.